### PR TITLE
chore: bind to 0.0.0.0

### DIFF
--- a/3/README.md
+++ b/3/README.md
@@ -62,6 +62,9 @@ spec:
   containers:
     - image: launcher.gcr.io/google/mongodb3
       name: mongo
+      args:
+        - --bind_ip
+        - 0.0.0.0
 ```
 
 Run the following to expose the port.
@@ -95,6 +98,9 @@ spec:
   containers:
     - image: launcher.gcr.io/google/mongodb3
       name: mongo
+      args:
+        - --bind_ip
+        - 0.0.0.0
       volumeMounts:
         - name: data
           mountPath: /data/db
@@ -150,6 +156,8 @@ spec:
     - image: launcher.gcr.io/google/mongodb3
       name: mongo
       args:
+        - --bind_ip
+        - 0.0.0.0
         - --storageEngine wiredTiger
 ```
 
@@ -191,6 +199,8 @@ spec:
     - image: launcher.gcr.io/google/mongodb3
       name: mongo
       args:
+        - --bind_ip
+        - 0.0.0.0
         - --auth
 ```
 


### PR DESCRIPTION
The default behavior of mongo is to bind to localhost which, makes
it impossible to access the mongo instance from outside the pod.
Having mongo bind to 0.0.0.0 allows it to be accessed from
outside the pod.